### PR TITLE
Fix parameters for the DidScanBarcode event handler

### DIFF
--- a/Code9.Scandit/Android/Scan/ScannerDroid.cs
+++ b/Code9.Scandit/Android/Scan/ScannerDroid.cs
@@ -117,7 +117,7 @@ namespace Code9.Android
 			//Do nothing
 		}
 
-		public void DidScanBarcode (string type, string barcode)
+		public void DidScanBarcode (string barcode, string type)
 		{
 			this.Finish ();
 			if (OnScanCompleted != null) {


### PR DESCRIPTION
Parameters for the DidScanBarcode event handler are barcode and type, in this order.
